### PR TITLE
Don't use readlines; prefer lazy iteration

### DIFF
--- a/httplang/httplang.py
+++ b/httplang/httplang.py
@@ -4,7 +4,7 @@ import utils
 
 def run(file_):
     with open(file_, 'rb') as file:
-        for line in file.readlines():
+        for line in file:
             parse.parse(line)
     return utils.baseVariables
 


### PR DESCRIPTION
`readlines()` reads the whole file into a list in memory unnecessarily. Simply iterate over the file to read lines on demand.
