### PR TITLE
pretty printing

### DIFF
--- a/examples/prettyget.http
+++ b/examples/prettyget.http
@@ -1,0 +1,3 @@
+set URL http://google.com/
+do GET /
+prettyprint $HTML

--- a/httplang/prettyprint.py
+++ b/httplang/prettyprint.py
@@ -1,0 +1,8 @@
+import utils
+from bs4 import BeautifulSoup as bs
+
+
+def prettyprint(line):
+    soup = bs(utils.typeDetermin(line[1]))
+    prettyHTML = soup.prettify().encode('UTF-8')
+    print prettyHTML

--- a/httplang/utils.py
+++ b/httplang/utils.py
@@ -3,6 +3,7 @@ import setvar
 import sys
 import show
 import getvalue
+import prettyprint
 
 lines = 0
 
@@ -27,6 +28,7 @@ keywords = {
         "set":setvar.setvar,
         "show":show.show,        
         "getvalue":getvalue.getvalue,
+        "prettyprint":prettyprint.prettyprint,
 
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lxml>=3.2.3
+beautifulsoup4>=4.3.2


### PR DESCRIPTION
Used BeautifulSoup's prettyprint to add a pretty print function to print
HTML nicely. It is UTF-8 compliant.

However, there are two ways of doing this - 
1. Use 'show' command with arguments - 
     show $HTML prettyprint
2. Use new command prettyprint to print - 
     prettyprint $HTML

I've used the latter, because  I didn't want to meddle with your code. Please see if this is the approach you want to use.

EDIT: Also, note that using BeautifulSoup is a good approach as opposed to lxml's own internal parser because it's more powerful, universal and can do more interesting things with the HTML output down the line.
