### PR TITLE
Made module call main code

### DIFF
--- a/httplang/__init__.py
+++ b/httplang/__init__.py
@@ -2,7 +2,4 @@ from . import httplang
 import sys
 
 def console_main():
-	if len(sys.argv) < 2:
-	    sys.exit("Usage: ./httplang <file.http>")
-
-	httplang.run(sys.argv[1])
+	httplang.main()

--- a/httplang/httplang.py
+++ b/httplang/httplang.py
@@ -3,6 +3,13 @@ import sys
 import utils
 import repl
 
+def main():
+    if len(sys.argv) < 2:
+        repl.enterREPL()
+        sys.exit()
+    inputFile = sys.argv[1]
+    run(inputFile)
+
 def run(file_):
     with open(file_, 'rb') as file:
         for line in file:
@@ -10,8 +17,4 @@ def run(file_):
     return utils.baseVariables
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        repl.enterREPL()
-        sys.exit()
-    inputFile = sys.argv[1]
-    run(inputFile)
+    main()


### PR DESCRIPTION
Was experiencing issues where the program wouldn't enter the REPL when installed as a module. Figured this was due to the module file `__init__.py` essientally reimplementing the main code in `httplang.py` except it lacked the REPL code I added. The module function now calls the main function in `httplang.py` so all should be good and working.
