### PR TITLE
typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='HTTPLang',
           'console_scripts': ['httplang=httplang:console_main'],
       },
       url='https://github.com/Max00355/HTTPLang',
-      description='A scripting langauge to do HTTP routines.',
+      description='A scripting language to do HTTP routines.',
       classifiers=[
           'Operating System :: POSIX',
           'Programming Language :: Python',


### PR DESCRIPTION
it is common mistake. Nothing special, just another typo of "language" word.